### PR TITLE
fixed current citation format

### DIFF
--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -24,12 +24,8 @@ const GetCitation = ({ nodes }) => {
     return a["submission_date"] > b["submission_date"];
   });
 
-  // Return the submitters across all docs that are distinct
-  var submitters = [];
-  docs.forEach(element => {
-    submitters.push(getFormattedName(element["submitters"][0]));
-  });
-  let submitterCite = [...new Set(submitters)];
+  // Only return the earliest submitter
+  let submitterCite = getFormattedName(docs[0]["submitters"][0]);
 
   var incidentDate = docs[0]["incident_date"];
   var submissionDate = docs[0]["submission_date"];
@@ -54,17 +50,8 @@ function BibTex({ nodes }) {
     return a["submission_date"] > b["submission_date"];
   });
 
-  // Return the submitters across all docs that are distinct
-  var submitters = [];
-  docs.forEach(element => {
-    let split = element["submitters"][0].split(" ");
-    if (split.length > 1) {
-      submitters.push(`${split[split.length - 1]}, ${split.slice(0, split.length - 1).join(" ")}`);
-    } else {
-      submitters.push(element["submitters"][0]);
-    }
-  });//Only supporting the first submitter on the doc
-  let submitterCite = [...new Set(submitters)];
+  // Only return the earliest submitter
+  let submitterCite = getFormattedName(docs[0]["submitters"][0]);
 
   var incidentDate = docs[0]["incident_date"];
   var submissionDate = docs[0]["submission_date"];

--- a/site/gatsby-site/src/utils/typography.js
+++ b/site/gatsby-site/src/utils/typography.js
@@ -22,6 +22,11 @@ export function getFormattedName(str) {
     return str;
   }
 
+  // Special case of organizational collaboration
+  if(str === "CSET annotators") {
+    return str;
+  }
+
   if (checkParenthetical(split[split.length - 1])) {
     const lastWord = split.pop();
     if (split.length > 1) {
@@ -31,5 +36,7 @@ export function getFormattedName(str) {
       // One word + parenthesized word, return origin
       return str;
     }
+  } else {
+    return `${split[split.length - 1]}, ${split.slice(0, split.length - 1).join(" ")}`;
   }
 }


### PR DESCRIPTION
Fixes #55

This simplifies the citation format to include only the earliest submitter and has a special callout for the CSET annotators since they have a set of submissions without an individual associated. I plan on making more substantive changes to the citations this weekend for #46 