### PR TITLE
Add first verison of RSS Feed

### DIFF
--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -109,7 +109,6 @@ const plugins = [
         {
           serialize: ({ query: { allMongodbAiidprodIncidents } }) => {
             return allMongodbAiidprodIncidents.edges.map((edge) => {
-              console.log({ edge });
               return Object.assign({}, edge.node.frontmatter, {
                 title: edge.node.title,
                 url: edge.node.url,
@@ -120,7 +119,7 @@ const plugins = [
           },
           query: `
             {
-              allMongodbAiidprodIncidents {
+              allMongodbAiidprodIncidents(sort: {fields: date_published, order: DESC}, limit: 100) {
                 totalCount
                 edges {
                   node {

--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -114,18 +114,26 @@ const plugins = [
                 url: edge.node.url,
                 link: edge.node.url,
                 description: edge.node.description,
+                guid: edge.node.id,
+                enclosure: edge.node.image_url &&
+                  edge.node.image_url !== 'placeholder.svg' && {
+                    url: edge.node.image_url,
+                    type: 'image/jpeg',
+                  },
               });
             });
           },
           query: `
             {
-              allMongodbAiidprodIncidents(sort: {fields: date_published, order: DESC}, limit: 100) {
+              allMongodbAiidprodIncidents(sort: {fields: date_submitted, order: DESC}, limit: 100) {
                 totalCount
                 edges {
                   node {
                     title
                     url
                     description
+                    id
+                    image_url
                   }
                 }
               }

--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -1,4 +1,6 @@
 require('dotenv').config();
+const md5 = require('md5');
+
 const queries = require('./src/utils/algolia');
 
 const config = require('./config');
@@ -117,7 +119,10 @@ const plugins = [
                 guid: edge.node.id,
                 enclosure: edge.node.image_url &&
                   edge.node.image_url !== 'placeholder.svg' && {
-                    url: edge.node.image_url,
+                    url:
+                      config.gatsby.siteUrl +
+                      '/large_media/report_banners/' +
+                      md5(edge.node.image_url),
                     type: 'image/jpeg',
                   },
               });

--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -90,6 +90,54 @@ const plugins = [
       },
     },
   },
+  {
+    resolve: 'gatsby-plugin-feed',
+    options: {
+      query: `
+        {
+          site {
+            siteMetadata {
+              title
+              description
+              siteUrl
+              site_url: siteUrl
+            }
+          }
+        }
+      `,
+      feeds: [
+        {
+          serialize: ({ query: { allMongodbAiidprodIncidents } }) => {
+            return allMongodbAiidprodIncidents.edges.map((edge) => {
+              console.log({ edge });
+              return Object.assign({}, edge.node.frontmatter, {
+                title: edge.node.title,
+                url: edge.node.url,
+                link: edge.node.url,
+                description: edge.node.description,
+              });
+            });
+          },
+          query: `
+            {
+              allMongodbAiidprodIncidents {
+                totalCount
+                edges {
+                  node {
+                    title
+                    url
+                    description
+                  }
+                }
+              }
+            }
+          `,
+          output: '/rss.xml',
+          title: 'AI Incident Database RSS Feed',
+        },
+      ],
+    },
+  },
 ];
 
 // check and add algolia

--- a/site/gatsby-site/gatsby-node.js
+++ b/site/gatsby-site/gatsby-node.js
@@ -3,19 +3,21 @@ const path = require('path');
 const startCase = require('lodash.startcase');
 
 const config = require('./config');
+
 const createMdxPages = require('./page-creators/createMdxPages');
+
 const createCitiationPages = require('./page-creators/createCitiationPages');
+
 const createWordCountsPages = require('./page-creators/createWordCountsPage');
 
 exports.createPages = ({ graphql, actions }) => {
-
   const { createPage } = actions;
 
   return Promise.all([
     createMdxPages(graphql, createPage),
     createCitiationPages(graphql, createPage),
     createWordCountsPages(graphql, createPage),
-  ])
+  ]);
 };
 
 exports.onCreateWebpackConfig = ({ actions }) => {
@@ -23,7 +25,7 @@ exports.onCreateWebpackConfig = ({ actions }) => {
     resolve: {
       modules: [path.resolve(__dirname, 'src'), 'node_modules'],
       alias: {
-        "@components": path.resolve(__dirname, 'src/components'),
+        '@components': path.resolve(__dirname, 'src/components'),
         buble: '@philpl/buble', // to reduce bundle size
       },
     },
@@ -80,5 +82,5 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 const express = require('express');
 
 exports.onCreateDevServer = ({ app }) => {
-  app.use(express.static('public'))
-}
+  app.use(express.static('public'));
+};

--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -28,6 +28,7 @@
     "gatsby-plugin-algolia": "^0.5.0",
     "gatsby-plugin-catch-links": "^2.3.11",
     "gatsby-plugin-emotion": "^4.1.18",
+    "gatsby-plugin-feed": "^2.13.0",
     "gatsby-plugin-gtag": "^1.0.12",
     "gatsby-plugin-layout": "^1.1.18",
     "gatsby-plugin-manifest": "^2.2.33",

--- a/site/gatsby-site/src/components/Header.js
+++ b/site/gatsby-site/src/components/Header.js
@@ -179,11 +179,7 @@ const Header = ({ location, isDarkThemeActive }) => (
                   </li>
                 ) : null}
                 <li className={'displayFlex'}>
-                  <a
-                    href={'http://localhost:8000/rss.xml'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <a href={'/rss.xml'} target="_blank" rel="noopener noreferrer">
                     <img src={rssFeed} alt={'RSSFeed'} />
                   </a>
                 </li>

--- a/site/gatsby-site/src/components/Header.js
+++ b/site/gatsby-site/src/components/Header.js
@@ -52,6 +52,15 @@ const StyledBgDiv = styled('div')`
   }
 `;
 
+const GrayscaleDiv = styled.div`
+  display: flex;
+  img {
+    -webkit-filter: grayscale(1);
+    filter: gray;
+    filter: grayscale(1);
+  }
+`;
+
 const Header = ({ location, isDarkThemeActive }) => (
   <StaticQuery
     query={graphql`
@@ -178,10 +187,12 @@ const Header = ({ location, isDarkThemeActive }) => (
                     </GitHubButton>
                   </li>
                 ) : null}
-                <li className={'displayFlex'}>
-                  <a href={'/rss.xml'} target="_blank" rel="noopener noreferrer">
-                    <img src={rssFeed} alt={'RSSFeed'} />
-                  </a>
+                <li>
+                  <GrayscaleDiv>
+                    <a href={'/rss.xml'} target="_blank" rel="noopener noreferrer">
+                      <img src={rssFeed} alt={'RSSFeed'} />
+                    </a>
+                  </GrayscaleDiv>
                 </li>
               </ul>
             </div>

--- a/site/gatsby-site/src/components/Header.js
+++ b/site/gatsby-site/src/components/Header.js
@@ -79,6 +79,8 @@ const Header = ({ location, isDarkThemeActive }) => (
 
       const twitter = require('./images/twitter.svg');
 
+      const rssFeed = require('./images/rssFeed.svg');
+
       const {
         site: {
           siteMetadata: { headerTitle, githubUrl, helpUrl, tweetText, logo, headerLinks },
@@ -176,6 +178,15 @@ const Header = ({ location, isDarkThemeActive }) => (
                     </GitHubButton>
                   </li>
                 ) : null}
+                <li className={'displayFlex'}>
+                  <a
+                    href={'http://localhost:8000/rss.xml'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img src={rssFeed} alt={'RSSFeed'} />
+                  </a>
+                </li>
               </ul>
             </div>
           </nav>

--- a/site/gatsby-site/src/components/images/rssFeed.svg
+++ b/site/gatsby-site/src/components/images/rssFeed.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="256" height="256" id="svg2" sodipodi:version="0.32" inkscape:version="0.47 r22583" sodipodi:docname="rss-feed.svg" version="1.0" inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs id="defs4">
+    <linearGradient inkscape:collect="always" id="linearGradient2555">
+      <stop style="stop-color: rgb(255, 255, 255); stop-opacity: 1;" offset="0" id="stop2557"/>
+      <stop style="stop-color: rgb(255, 255, 255); stop-opacity: 0;" offset="1" id="stop2559"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2555" id="linearGradient2449" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.5914583,0,0,0.5914584,210.0216,142.2324)" x1="-344.15295" y1="274.711" x2="-395.84943" y2="425.39993"/>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="0.35" inkscape:cx="430.42472" inkscape:cy="131.48311" inkscape:document-units="px" inkscape:current-layer="layer1" inkscape:window-width="782" inkscape:window-height="674" inkscape:window-x="1" inkscape:window-y="281" showgrid="false" inkscape:window-maximized="0"/>
+  <metadata id="metadata7">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title/>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag/>
+        </dc:subject>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/publicdomain/"/>
+        <dc:description/>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title/>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(-373.642,-318.344)">
+    <rect inkscape:export-ydpi="7.7063322" inkscape:export-xdpi="7.7063322" inkscape:export-filename="C:\Documents and Settings\Molumen\Desktop\path3511111.png" transform="scale(-1,1)" ry="35.487503" rx="35.487503" y="328.84921" x="-619.14587" height="234.98955" width="235.00784" id="rect1942" style="fill:#e15a00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.87500000000000000;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.87500000000000000, 1.75000000000000000;stroke-dashoffset:0;stroke-opacity:1"/>
+    <path inkscape:export-ydpi="7.7063322" inkscape:export-xdpi="7.7063322" inkscape:export-filename="C:\Documents and Settings\Molumen\Desktop\path3511111.png" sodipodi:nodetypes="ccccsssc" id="path1950" d="M 557.05665,338.89518 L 446.22721,338.89518 C 416.89033,338.89518 393.27256,362.70492 393.27256,392.28025 L 393.27256,500.40761 C 394.22216,523.49366 397.87485,508.89915 404.82758,483.3329 C 412.90814,453.61975 439.22406,427.65003 471.27219,408.1872 C 495.73352,393.33195 523.11328,383.84595 572.95174,382.94353 C 601.21656,382.43177 598.72124,346.26062 557.05665,338.89518 z" style="opacity:0.60747664;fill:url(#linearGradient2449);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.87500000000000000;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.87500000000000000, 1.75000000000000000;stroke-dashoffset:0;stroke-opacity:1"/>
+    <path sodipodi:type="arc" style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:12;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" id="path5270" sodipodi:cx="360.35715" sodipodi:cy="200.64285" sodipodi:rx="24.642859" sodipodi:ry="23.928572" d="m 385.00001,200.64285 c 0,13.21539 -11.03299,23.92857 -24.64286,23.92857 -13.60988,0 -24.64286,-10.71318 -24.64286,-23.92857 0,-13.21538 11.03298,-23.92857 24.64286,-23.92857 13.60987,0 24.64286,10.71319 24.64286,23.92857 z" transform="matrix(0.8699574,0,0,0.8699574,135.15631,330.52863)"/>
+    <path style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 427.83482,455.05681 L 427.76203,424.78365 C 492.4681,428.1591 528.38081,474.45682 529.26224,526.72326 L 498.944,526.72326 C 498.44099,480.78249 467.20335,456.72804 427.83482,455.05681 z" id="path5805" sodipodi:nodetypes="ccccc"/>
+    <path style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 428.20143,404.57149 L 427.32264,373.81385 C 526.75104,378.43011 580.00028,450.58197 580.67143,526.72326 L 549.4744,526.28386 C 550.83932,477.58037 514.80871,406.01731 428.20143,404.57149 z" id="path5807" sodipodi:nodetypes="ccccc"/>
+  </g>
+</svg>

--- a/site/gatsby-site/src/components/styles/GlobalStyles.js
+++ b/site/gatsby-site/src/components/styles/GlobalStyles.js
@@ -626,10 +626,6 @@ export const baseStyles = injectGlobal`
     align-items: center;
   }
 
-  .displayFlex {
-    display: flex;
-  }
-
   .communitySection {
     font-size: 24px;
     font-weight: 700;

--- a/site/gatsby-site/src/components/styles/GlobalStyles.js
+++ b/site/gatsby-site/src/components/styles/GlobalStyles.js
@@ -320,7 +320,7 @@ export const baseStyles = injectGlobal`
     border: 0 !important;
     background-color: rgb(245, 247, 249); /* !important; */
   }
-  
+
   blockquote {
     color: rgb(116, 129, 141);
     margin: 0px 0px 24px;
@@ -624,6 +624,10 @@ export const baseStyles = injectGlobal`
   .githubBtn span span {
     display: flex;
     align-items: center;
+  }
+
+  .displayFlex {
+    display: flex;
   }
 
   .communitySection {


### PR DESCRIPTION
Hey @smcgregor so right now we are fetching the title, URL of the article referred in the incident and description for all incidents.

It looks like this:

![image](https://user-images.githubusercontent.com/7571224/109165217-f9c83200-7783-11eb-9d85-f401034c924c.png)

Let me know if we should do something different with the formatting or with the query. From what I understood this RSS feed is supposed to return all incidents.