### PR TITLE
Create UserContext and realm service, useMongo hook

### DIFF
--- a/site/gatsby-site/src/contexts/userContext/UserContext.js
+++ b/site/gatsby-site/src/contexts/userContext/UserContext.js
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+
+export const UserContext = createContext({
+  loading: false,
+  user: null,
+  mongoUserKey: '',
+  isAdmin: false,
+  isLoggedIn: false,
+  actions: {
+    setUserAPIKey: () => {},
+    logout: () => {},
+  },
+});
+export const useUserContext = () => useContext(UserContext);

--- a/site/gatsby-site/src/contexts/userContext/UserContextProvider.js
+++ b/site/gatsby-site/src/contexts/userContext/UserContextProvider.js
@@ -1,0 +1,80 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import * as Realm from 'realm-web';
+
+import { realmApp } from 'services/realmApp';
+
+import { UserContext } from './UserContext';
+
+// A MongoDB interface component managing the privileged user state.
+// There are two authentication states for the API:
+//
+// 1. Anonymous users. These are permitted to make submissions to the database, but they
+//    are not permitted to accept reports into the main incident database.
+// 2. Authenticated users. These are permitted to accept reports into the database.
+//
+// Authenticated token users are added to the database in the MongoDB UI.
+//
+// https://docs.mongodb.com/realm/web/mongodb/
+
+export const UserContextProvider = ({ children }) => {
+  const [loading, setLoading] = useState(false);
+  const [user, setUser] = useState();
+  const [type, setType] = useState();
+  const [mongoUserKey, setMongoUserKey] = useState();
+
+  const setUserAPIKey = useCallback((apiKey) => {
+    setMongoUserKey(apiKey);
+    window.localStorage.setItem('mongoUserKey', apiKey);
+  }, []);
+
+  const logout = useCallback(() => {
+    window.localStorage.removeItem('mongoUserKey');
+  }, []);
+
+  useEffect(() => {
+    const apiKey = window.localStorage.getItem('mongoUserKey');
+    setMongoUserKey(apiKey);
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    const credentials = mongoUserKey
+      ? Realm.Credentials.apiKey(mongoUserKey)
+      : Realm.Credentials.anonymous();
+    setType(mongoUserKey ? 'token' : 'anonymous');
+
+    realmApp
+      .logIn(credentials)
+      .then((res) => {
+        setUser(res);
+        console.log(`Logged in as ${type} user:`, user);
+      })
+      .catch((e) => {
+        console.log('RealmApp login Failed: ', e);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [mongoUserKey]);
+
+  return (
+    <UserContext.Provider
+      value={useMemo(
+        () => ({
+          loading,
+          user,
+          mongoUserKey,
+          isAdmin: type === 'token',
+          isLoggedIn: !!user,
+          actions: {
+            setUserAPIKey,
+            logout,
+          },
+        }),
+        [loading, user, type, setUserAPIKey, logout]
+      )}
+    >
+      {children}
+    </UserContext.Provider>
+  );
+};

--- a/site/gatsby-site/src/contexts/userContext/index.js
+++ b/site/gatsby-site/src/contexts/userContext/index.js
@@ -1,0 +1,2 @@
+export { UserContext, useUserContext } from './UserContext';
+export { UserContextProvider } from './UserContextProvider';

--- a/site/gatsby-site/src/hooks/useMongo.js
+++ b/site/gatsby-site/src/hooks/useMongo.js
@@ -1,0 +1,50 @@
+import { realmApp } from 'services/mongodb';
+import config from '../../config';
+
+// https://docs.mongodb.com/realm/web/mongodb/
+
+const DB_SERVICE = config.realm.review_db.db_service;
+const DB_NAME = config.realm.review_db.db_name;
+const DB_COLLECTION = config.realm.review_db.db_collection;
+
+export const useMongo = () => {
+  const runQuery = async (
+    query,
+    callback,
+    dbService = DB_SERVICE,
+    dbName = DB_NAME,
+    dbCollection = DB_COLLECTION
+  ) => {
+    const mongoCollection = realmApp.services
+      .mongodb(dbService)
+      .db(dbName)
+      .collection(dbCollection);
+
+    const res = await mongoCollection.find(query);
+
+    callback && callback(res);
+  };
+
+  const updateOne = async (
+    query,
+    data,
+    callback,
+    dbService = DB_SERVICE,
+    dbName = DB_NAME,
+    dbCollection = DB_COLLECTION
+  ) => {
+    const mongoCollection = realmApp.services
+      .mongodb(dbService)
+      .db(dbName)
+      .collection(dbCollection);
+
+    const res = await mongoCollection.updateOne(query, data);
+
+    callback && callback(res);
+  };
+
+  return {
+    runQuery,
+    updateOne,
+  };
+};

--- a/site/gatsby-site/src/services/realmApp.js
+++ b/site/gatsby-site/src/services/realmApp.js
@@ -1,0 +1,9 @@
+import * as Realm from 'realm-web';
+import config from '../../config';
+
+const REALM_APP_ID = config.realm.review_db.realm_app_id;
+
+export const realmApp = new Realm.App({
+  id: REALM_APP_ID,
+  timeout: 10 * 1000, // timeout in number of milliseconds
+});


### PR DESCRIPTION
- Auth state now can be delivered through UserContext
```
type UserContextValue = {
  loading: boolean;
  user: Realm.User;
  mongoUserKey: string;
  isAdmin: boolean;
  isLoggedIn: boolean;
  actions: {
    setUserAPIKey: (key: string) => void,
    logout: () => void
  }
}
```

- `runQuery` and `updateOne` API can be accessed through `useMongo` hook.
    