### PR TITLE
added taxa and classifications collections

### DIFF
--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -69,7 +69,7 @@ const plugins = [
     resolve: 'gatsby-source-mongodb',
     options: {
       dbName: 'aiidprod',
-      collection: ['incidents', 'submissions', 'quickadd', 'duplicates'],
+      collection: ['incidents', 'submissions', 'quickadd', 'duplicates', 'taxa', 'classifications'],
       connectionString:
         'mongodb+srv://readonlyuser:EScmnlEQHM1pWwWM@aiiddev-aqdmh.gcp.mongodb.net/AIIDDev',
       server: {


### PR DESCRIPTION
This adds the new `taxa` and `classifications` collections to the graphql interface in Gatsby. These collections are presently agile development targets for Issue [92](https://github.com/PartnershipOnAI/aiid/issues/92) and pull [144](https://github.com/PartnershipOnAI/aiid/pull/144). I plan on merging this immediately since it does not impact any current production functionality.