### PR TITLE
Increase debounce time for search discover app

### DIFF
--- a/site/gatsby-site/pages/apps/discover.js
+++ b/site/gatsby-site/pages/apps/discover.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { navigate } from 'gatsby';
 import { StringParam, QueryParams, useQueryParams } from 'use-query-params';
 import algoliasearch from 'algoliasearch/lite';
@@ -712,10 +712,20 @@ const IncidentCard = ({
   </IncidentCardContainer>
 );
 
-const StyledSearchBox = ({ refine, defaultRefinement, customRef }) => {
+const StyledSearchBox = ({ refine, customRef }) => {
+  // eslint-disable-next-line no-unused-vars
+  const [searchTerm, setSearchTerm] = useState('');
+
   const debouncedRefine = debounce((text) => {
     refine(text);
-  }, 700);
+  }, 500);
+
+  const debouceRefineCallback = useCallback((value) => debouncedRefine(value), []);
+
+  const handleOnChange = (e) => {
+    debouceRefineCallback(e.target.value);
+    setSearchTerm(e.target.value);
+  };
 
   return (
     <SearchContainer>
@@ -729,8 +739,7 @@ const StyledSearchBox = ({ refine, defaultRefinement, customRef }) => {
           spellCheck="false"
           maxLength="512"
           type="search"
-          defaultValue={defaultRefinement}
-          onChange={(event) => debouncedRefine(event.currentTarget.value)}
+          onChange={handleOnChange}
         />
         <SearchResetButton type="reset" title="Clear the search query." onClick={() => refine('')}>
           <FontAwesomeIcon

--- a/site/gatsby-site/pages/apps/discover.js
+++ b/site/gatsby-site/pages/apps/discover.js
@@ -715,7 +715,7 @@ const IncidentCard = ({
 const StyledSearchBox = ({ refine, defaultRefinement, customRef }) => {
   const debouncedRefine = debounce((text) => {
     refine(text);
-  }, 500);
+  }, 700);
 
   return (
     <SearchContainer>


### PR DESCRIPTION
Tries to fix #149 

I've increased the time it waits for new input before sending the request to algolia. Not sure if it fixes the problem 100%. Please let me know

Also tested multiple scenarios and use cases in order to make the search more responsive but we might have reached the limits of algolia-react module. So if we decide to do more optimisation we need to invest more time into this