### PR TITLE
fix key issues in citation page links

### DIFF
--- a/site/gatsby-site/pages/apps/discover.js
+++ b/site/gatsby-site/pages/apps/discover.js
@@ -538,13 +538,9 @@ const getParagraphs = (itemText) => {
   return (
     <>
       {itemText.split('\n').map((paragraph, index, array) => (
-        <>
-          {array.length - 1 === index ? (
-            <p key={index}>{paragraph + '...'}</p>
-          ) : (
-            <p key={index}>{paragraph}</p>
-          )}
-        </>
+        <p key={index}>
+          {array.length - 1 === index ? <>{paragraph + '...'}</> : <>{paragraph}</>}
+        </p>
       ))}
     </>
   );
@@ -605,7 +601,7 @@ const IncidentCard = ({
   toggleFilterByIncidentId,
   showDetails,
 }) => (
-  <IncidentCardContainer id={item._id}>
+  <IncidentCardContainer id={item.objectID}>
     <div className="card-header">
       <Highlight hit={item} attribute="title" />
       <p className="subhead">
@@ -1017,7 +1013,7 @@ const RenderCards = ({
       <>
         {sortedHits.map((hit) => (
           <IncidentCard
-            key={hit._id}
+            key={hit.objectID}
             item={hit}
             authorsModal={authorsModal}
             submittersModal={submittersModal}
@@ -1034,7 +1030,7 @@ const RenderCards = ({
     <>
       {hits.map((hit) => (
         <IncidentCard
-          key={hit._id}
+          key={hit.objectID}
           item={hit}
           authorsModal={authorsModal}
           submittersModal={submittersModal}

--- a/site/gatsby-site/src/components/IncidentList.js
+++ b/site/gatsby-site/src/components/IncidentList.js
@@ -19,7 +19,7 @@ const IncidentList = ({ group }) => {
             {value['edges'].map((value) => (
               <li key={value['node']['id']} className="d-flex">
                 <Date>{value['node']['date_published']}</Date>
-                <Link href={`#${value['node']['mongodb_id']}`}>{value['node']['title']}</Link>
+                <Link href={`${value['node']['url']}`}>{value['node']['title']}</Link>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
This resolves some duplicate key issues that were popping up in the console, and resolves an issue where the citation page links were not clicking through to the content returned by algolia.