### PR TITLE
Linkify links in edit queue and patch editing array fields

### DIFF
--- a/site/gatsby-site/src/components/EditableListItem.js
+++ b/site/gatsby-site/src/components/EditableListItem.js
@@ -65,6 +65,8 @@ const EditableListItem = ({ editable, onUpdate, name, value }) => {
 
   const toggleEditing = () => setEditing(!editing);
 
+  const isLink = name === 'image_url' || name === 'url';
+
   const handleSave = () => {
     onUpdate(inputRef.current.value);
     toggleEditing();
@@ -78,7 +80,13 @@ const EditableListItem = ({ editable, onUpdate, name, value }) => {
       <Col xs={12} lg={9} className="d-flex align-items-center">
         {!editing && (
           <EditButton onClick={toggleEditing} disabled={!editable}>
-            {value}
+            {isLink ? (
+              <a href={value} target="_blank" rel="noreferrer">
+                {value}
+              </a>
+            ) : (
+              value
+            )}
             {editable && <FontAwesomeIcon icon={faPen} size="xs" />}
           </EditButton>
         )}

--- a/site/gatsby-site/src/components/ReportedIncident.js
+++ b/site/gatsby-site/src/components/ReportedIncident.js
@@ -74,6 +74,12 @@ const ReportedIncident = ({ incident }) => {
   const handleUpdate = async (values) => {
     console.log('Updating report from: ', incident);
     console.log('Updating report to:', values);
+    if (typeof values['authors'] === 'string') {
+      values['authors'] = values['authors'].split(',').map((s) => s.trim());
+    }
+    if (typeof values['submitters'] === 'string') {
+      values['submitters'] = values['submitters'].split(',').map((s) => s.trim());
+    }
     updateOne({ _id: values._id }, values, refetch);
   };
 


### PR DESCRIPTION
* This makes it slightly easier to view linked assets in the review queue.
* This also patches an issue where the Formik library appears to be running an onchange handler on the CSV entries and changing the submitted type back from an array to a string type. A better way of solving this would have been to clear the data handling chain through formik and guarantee it produces an array, but there is too much background reading here to figure out what the library is doing in the background to figure out now. I will return to this later.