### PR TITLE
Move social links to the right on desktop

### DIFF
--- a/site/gatsby-site/src/components/Header.js
+++ b/site/gatsby-site/src/components/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import styled from 'styled-components';
 import { StaticQuery, graphql } from 'gatsby';
 import GitHubButton from 'react-github-btn';
 import Loadable from 'react-loadable';
@@ -58,11 +58,8 @@ const StyledBgDiv = styled('div')`
 const NavBarHeaderContainer = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: flex-start;
-
-  @media (max-width: 767px) {
-    justify-content: space-between;
-  }
+  justify-content: space-between;
+  width: 100%;
 `;
 
 const HeaderIconsContainer = styled.div`

--- a/site/gatsby-site/src/global.css
+++ b/site/gatsby-site/src/global.css
@@ -757,14 +757,14 @@ img {
     border-top: 1px solid #fff;
   }
   .headerTitle {
-    padding-right: 50px;
-    font-size: 16px;
+    font-size: 12px;
+    margin-top: 0;
   }
   .navBarBrand {
     min-height: 40px;
   }
   .navBarBrand img {
-    margin-right: 8px;
+    width: 42px;
   }
   .topnav.responsive .visibleMobile {
     display: block;
@@ -832,7 +832,6 @@ img {
     padding: 0 0;
     padding-left: 0;
     flex: initial;
-    padding-right: 15px;
   }
 
   .titleWrapper {


### PR DESCRIPTION
Also tweaked the mobile breakpoint a bit so it went from this:
![image](https://user-images.githubusercontent.com/1172479/131589629-9393e1c3-096f-4408-a3d5-0a96f5c5eb64.png)

To this:
![image](https://user-images.githubusercontent.com/1172479/131590754-599e5f8c-a140-42bd-ab25-ff262275695b.png)
