### PR TITLE
Revert Realm graphql pluralization setting in staging

### DIFF
--- a/site/realm/graphql/config.json
+++ b/site/realm/graphql/config.json
@@ -1,3 +1,3 @@
 {
-    "use_natural_pluralization": false
+    "use_natural_pluralization": true
 }


### PR DESCRIPTION
@cesarvarela this setting changing in staging after I updated from production and was breaking the build: https://github.com/PartnershipOnAI/aiid/runs/3855375618?check_suite_focus=true

I am not sure how the pluralization setting changed in production, so this won't necessarily fix things, but it is diagnostic.