### PR TITLE
fix string token replacement for older JS versions

### DIFF
--- a/site/gatsby-site/src/utils/discoverIndexGenerator.js
+++ b/site/gatsby-site/src/utils/discoverIndexGenerator.js
@@ -89,9 +89,9 @@ module.exports = async ({ graphql }) => {
         } else {
           valuesToUnpack = [cObj[c]];
         }
-        if (cObj[c] !== undefined && cObj[c] !== '' && valuesToUnpack.length > 0 && c.replaceAll) {
+        if (cObj[c] !== undefined && cObj[c] !== '' && valuesToUnpack.length > 0) {
           valuesToUnpack.forEach((element) =>
-            cArray.push(`${namespace}:${c.replaceAll('_', ' ')}:${element}`)
+            cArray.push(`${namespace}:${c.replace(/_/g, ' ')}:${element}`)
           );
         }
       }


### PR DESCRIPTION
`replaceAll` is a more recent string function, which was available on staging and not on the node version that was previously running on production. This change set means it should work on both versions.