### PR TITLE
WIP: Fix flagging

### DIFF
--- a/site/gatsby-site/src/components/IncidentCards.js
+++ b/site/gatsby-site/src/components/IncidentCards.js
@@ -27,7 +27,7 @@ const cardNeedsBlockquote = (item) => {
 
 const getFlagModalContent = () => (
   <div className="modal-body">
-    <p>Is there a problem with this content? Examples of &quot;problems`&quot;` include,</p>
+    <p>Is there a problem with this content? Examples of &quot;problems&quot; include,</p>
     <ul>
       <li>The text contents of the report are not parsed properly</li>
       <li>The authors of the report are not associated with the report</li>
@@ -48,8 +48,7 @@ const getFlagModalContent = () => (
     <p>Please do NOT flag content if,</p>
     <ul>
       <li>You disagree with the report</li>
-      <li>The linked report has disappeared from the web</li>
-      <li>The report should not be considered an `&quot;`incident`&quot;`</li>
+      <li>The report should not be considered an &quot;incident&quot;</li>
     </ul>
     <button type="button" className="btn btn-danger btn-sm w-100" data-dismiss="modal">
       Flag Report

--- a/site/gatsby-site/src/components/discover/hitTypes/Actions.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/Actions.js
@@ -12,7 +12,7 @@ import {
 
 const getFlagModalContent = () => (
   <div className="modal-body">
-    <p>Is there a problem with this content? Examples of &quot;problems`&quot;` include,</p>
+    <p>Is there a problem with this content? Examples of &quot;problems&quot; include,</p>
     <ul>
       <li>The text contents of the report are not parsed properly</li>
       <li>The authors of the report are not associated with the report</li>
@@ -33,8 +33,7 @@ const getFlagModalContent = () => (
     <p>Please do NOT flag content if,</p>
     <ul>
       <li>You disagree with the report</li>
-      <li>The linked report has disappeared from the web</li>
-      <li>The report should not be considered an `&quot;`incident`&quot;`</li>
+      <li>The report should not be considered an &quot;incident&quot;</li>
     </ul>
     <button type="button" className="btn btn-danger btn-sm w-100" data-dismiss="modal">
       Flag Report


### PR DESCRIPTION
Closes #301 

This is a work in progress. It looks to me like the flagging form may be completely disconnected from any backend endpoint and the flag was previously being set by MongoDB queries. So the next steps are to define a Realm function for flagging content and make that function open to all anonymous users.