### PR TITLE
Add schema definitions to deal with conflicting types warning

### DIFF
--- a/site/gatsby-site/gatsby-node.js
+++ b/site/gatsby-site/gatsby-node.js
@@ -173,6 +173,15 @@ exports.createSchemaCustomization = ({ actions }) => {
     type mongodbAiidprodTaxaField_list implements Node {
       render_as: String
     }  
+    
+    type mongodbAiidprodTaxa implements Node {
+      field_list: [mongodbAiidprodTaxaField_list]
+    }
+
+    type mongodbAiidprodTaxaField_list {
+      default: String
+      placeholder: String
+    }
   `;
 
   createTypes(typeDefs);


### PR DESCRIPTION
This fixes the issue with the fields not being exposed in the graphql endpoint, but there doesn't seem to be a way to silence the warning itself:

```
If you have explicitly defined a type for those fields, you can safely ignore this warning message.
```
