### PR TITLE
Remove date mock since doesn't seem to be working

### DIFF
--- a/site/gatsby-site/cypress/integration/cite.js
+++ b/site/gatsby-site/cypress/integration/cite.js
@@ -144,8 +144,6 @@ describe('Cite pages', () => {
   });
 
   it('Should pre-fill submit report form', () => {
-    cy.clock(Date.UTC(2022, 2, 2), ['Date']);
-
     cy.visit(url);
 
     cy.contains('New Report').scrollIntoView().click();
@@ -153,7 +151,5 @@ describe('Cite pages', () => {
     cy.get('[name="incident_id"]').should('have.value', '10');
 
     cy.get('[name="incident_date"]').should('have.value', '2014-08-14');
-
-    cy.get('[name="date_downloaded"]').should('have.value', '2022-03-02');
   });
 });


### PR DESCRIPTION
Mocking Date from cypress does funny things within Gatsby: https://github.com/gatsbyjs/gatsby/issues/12601, and I couldn't find a solution, so let's remove the test.

closes #494 